### PR TITLE
change the landing page floating animation

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useEffect, useRef, useState, ReactNode } from 'react';
 import { Logo } from './VizoraLogo';
 import { useAuth } from '../context/AuthContext';
-import { motion, useSpring, useReducedMotion } from 'framer-motion';
+import { motion, useSpring, useReducedMotion, useScroll, useTransform } from 'framer-motion';
 
 interface CursorReactiveCardProps {
   children: ReactNode;
@@ -92,6 +92,13 @@ export function Hero() {
   const [, setDistances] = useState<Record<string, number>>({});
   const [activeId, setActiveId] = useState<string | null>(null);
 
+  const { scrollY } = useScroll();
+  const flyOutLeft = useTransform(scrollY, [0, 500], [0, -300]);
+  const flyOutRight = useTransform(scrollY, [0, 500], [0, 300]);
+  const flyOutUp = useTransform(scrollY, [0, 500], [0, -200]);
+  const flyOutDown = useTransform(scrollY, [0, 500], [0, 200]);
+  const scrollOpacity = useTransform(scrollY, [0, 400], [1, 0]);
+
   const handleDistanceChange = (id: string, distance: number) => {
     setDistances(prev => {
       const newDistances = { ...prev, [id]: distance };
@@ -174,6 +181,109 @@ export function Hero() {
         </div>
       </div>
 
+      {/* Floating cards wrapper - Behind text layer */}
+      <div className="absolute inset-0 pointer-events-none z-0 hidden lg:block opacity-80">
+        <div className="app-container h-full relative">
+          {/* Card 1: Schema Note (Top Left) - FAR - Visible behind text */}
+          <motion.div style={{ x: flyOutLeft, y: flyOutUp, opacity: scrollOpacity }} className="absolute inset-0">
+            <CursorReactiveCard id="note" activeId={activeId} onDistanceChange={handleDistanceChange} depth="far" className="top-32 left-8">
+              <div className="bg-[#fffde7] p-5 rounded-sm shadow-[0_8px_30px_rgb(0,0,0,0.06)] ring-1 ring-yellow-200/50 -rotate-6 w-56 flex-col gap-2 cursor-default select-none transition-transform pointer-events-auto">
+                <div className="w-2.5 h-2.5 rounded-full bg-red-400 mx-auto mb-1 shadow-sm"></div>
+                <p className="font-handwriting text-slate-700 text-sm leading-snug">
+                  "This table stores completed orders and links users to payments."
+                </p>
+              </div>
+            </CursorReactiveCard>
+          </motion.div>
+
+          {/* Card 2: ER Diagram Preview (Top Right) - NEAR - Visible behind text */}
+          <motion.div style={{ x: flyOutRight, y: flyOutUp, opacity: scrollOpacity }} className="absolute inset-0">
+            <CursorReactiveCard id="diagram" activeId={activeId} onDistanceChange={handleDistanceChange} depth="near" className="top-36 right-8">
+              <div className="bg-white p-5 rounded-2xl shadow-[0_20px_50px_rgb(0,0,0,0.08)] ring-1 ring-slate-200/60 rotate-6 w-64 flex-col gap-4 cursor-default transition-transform pointer-events-auto">
+                <div className="flex items-center gap-2 mb-1">
+                  <div className="p-1.5 bg-indigo-50 rounded-md">
+                    <Share2 className="w-3.5 h-3.5 text-indigo-600" />
+                  </div>
+                  <span className="text-xs font-bold text-slate-800 uppercase tracking-wider">ER Diagram</span>
+                </div>
+                <div className="relative h-28 border border-slate-100 rounded-lg bg-slate-50 p-3 overflow-hidden">
+                  <div className="absolute top-2 left-2 bg-white border border-slate-200 shadow-sm rounded px-2 py-1 text-[8px] font-bold text-slate-700 w-16 text-center z-10">
+                    users
+                  </div>
+                  <div className="absolute top-12 right-4 bg-white border border-slate-200 shadow-sm rounded px-2 py-1 text-[8px] font-bold text-slate-700 w-16 text-center z-10">
+                    orders
+                  </div>
+                  <div className="absolute bottom-2 left-8 bg-white border border-slate-200 shadow-sm rounded px-2 py-1 text-[8px] font-bold text-slate-700 w-16 text-center z-10">
+                    payments
+                  </div>
+                  <svg className="absolute inset-0 w-full h-full pointer-events-none overflow-visible">
+                    <path d="M40 18 C 60 18, 80 40, 90 50" fill="none" stroke="#94a3b8" strokeWidth="1.5" strokeLinecap="round" />
+                    <path d="M90 65 C 80 80, 60 90, 50 90" fill="none" stroke="#94a3b8" strokeWidth="1.5" strokeLinecap="round" />
+                  </svg>
+                </div>
+              </div>
+            </CursorReactiveCard>
+          </motion.div>
+
+          {/* Card 3: Schema Changes (Bottom Left) - NEAR - Visible behind text */}
+          <motion.div style={{ x: flyOutLeft, y: flyOutDown, opacity: scrollOpacity }} className="absolute inset-0">
+            <CursorReactiveCard id="updates" activeId={activeId} onDistanceChange={handleDistanceChange} depth="near" className="bottom-32 left-8">
+              <div className="bg-white p-5 rounded-2xl shadow-[0_20px_40px_rgb(0,0,0,0.06)] ring-1 ring-slate-200/60 rotate-3 w-64 cursor-default transition-transform pointer-events-auto">
+                <div className="flex items-center gap-2 mb-3">
+                  <div className="p-1.5 bg-green-50 rounded-md">
+                    <Layers className="w-3.5 h-3.5 text-green-600" />
+                  </div>
+                  <span className="text-xs font-bold text-slate-800 uppercase tracking-wider">Schema Updates</span>
+                </div>
+                <div className="space-y-2.5">
+                  <div className="flex items-center gap-2 text-xs text-slate-600 bg-slate-50 p-2 rounded-lg border border-slate-100">
+                    <div className="w-1.5 h-1.5 rounded-full bg-green-500"></div>
+                    <span className="font-mono text-slate-800">users.email</span>
+                    <span className="ml-auto text-[10px] bg-green-100 text-green-700 px-1.5 py-0.5 rounded font-bold">ADDED</span>
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-slate-600 bg-slate-50 p-2 rounded-lg border border-slate-100">
+                    <div className="w-1.5 h-1.5 rounded-full bg-amber-500"></div>
+                    <span className="font-mono text-slate-800">orders.status</span>
+                    <span className="ml-auto text-[10px] bg-amber-100 text-amber-700 px-1.5 py-0.5 rounded font-bold">MOD</span>
+                  </div>
+                </div>
+              </div>
+            </CursorReactiveCard>
+          </motion.div>
+
+          {/* Card 4: Export Options (Bottom Right) - FAR - Visible behind text */}
+          <motion.div style={{ x: flyOutRight, y: flyOutDown, opacity: scrollOpacity }} className="absolute inset-0">
+            <CursorReactiveCard id="export" activeId={activeId} onDistanceChange={handleDistanceChange} depth="far" className="bottom-28 right-8">
+              <div className="bg-white p-5 rounded-2xl shadow-[0_20px_40px_rgb(0,0,0,0.06)] ring-1 ring-slate-200/60 -rotate-6 cursor-default transition-transform pointer-events-auto">
+                <div className="flex items-center gap-2 mb-4">
+                  <div className="p-1.5 bg-blue-50 rounded-md">
+                    <FileText className="w-3.5 h-3.5 text-blue-600" />
+                  </div>
+                  <span className="text-xs font-bold text-slate-800 uppercase tracking-wider">Export documentation</span>
+                </div>
+                <div className="flex gap-3">
+                  <div className="flex flex-col items-center gap-1.5">
+                    <div className="w-10 h-10 bg-slate-50 rounded-lg flex items-center justify-center border border-slate-200 text-slate-400">
+                      <span className="text-[10px] font-bold">PNG</span>
+                    </div>
+                  </div>
+                  <div className="flex flex-col items-center gap-1.5">
+                    <div className="w-10 h-10 bg-slate-50 rounded-lg flex items-center justify-center border border-slate-200 text-slate-400">
+                      <span className="text-[10px] font-bold">SVG</span>
+                    </div>
+                  </div>
+                  <div className="flex flex-col items-center gap-1.5">
+                    <div className="w-10 h-10 bg-indigo-50 rounded-lg flex items-center justify-center border border-indigo-100 text-indigo-600 shadow-sm">
+                      <FileCode className="w-5 h-5" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </CursorReactiveCard>
+          </motion.div>
+        </div>
+      </div>
+
       {/* Hero Content (Center) */}
       <div className="flex-1 flex flex-col items-center justify-center z-20 relative w-full pt-20">
         <div className="app-container text-center">
@@ -207,100 +317,7 @@ export function Hero() {
           </div>
         </div>
 
-        {/* Floating cards wrapper - Locked to container width */}
-        <div className="absolute inset-0 pointer-events-none z-10 hidden lg:block">
-          <div className="app-container h-full relative">
-            {/* Card 1: Schema Note (Top Left) - FAR */}
-            <CursorReactiveCard id="note" activeId={activeId} onDistanceChange={handleDistanceChange} depth="far" className="top-40 left-0">
-              <div className="bg-[#fffde7] p-5 rounded-sm shadow-[0_8px_30px_rgb(0,0,0,0.06)] ring-1 ring-yellow-200/50 -rotate-3 w-56 flex-col gap-2 cursor-default select-none transition-transform pointer-events-auto">
-                <div className="w-2.5 h-2.5 rounded-full bg-red-400 mx-auto mb-1 shadow-sm"></div>
-                <p className="font-handwriting text-slate-700 text-sm leading-snug">
-                  "This table stores completed orders and links users to payments."
-                </p>
-              </div>
-            </CursorReactiveCard>
 
-            {/* Card 2: ER Diagram Preview (Right) - NEAR */}
-            <CursorReactiveCard id="diagram" activeId={activeId} onDistanceChange={handleDistanceChange} depth="near" className="top-48 right-0">
-              <div className="bg-white p-5 rounded-2xl shadow-[0_20px_50px_rgb(0,0,0,0.08)] ring-1 ring-slate-200/60 rotate-2 w-64 flex-col gap-4 cursor-default transition-transform pointer-events-auto">
-                <div className="flex items-center gap-2 mb-1">
-                  <div className="p-1.5 bg-indigo-50 rounded-md">
-                    <Share2 className="w-3.5 h-3.5 text-indigo-600" />
-                  </div>
-                  <span className="text-xs font-bold text-slate-800 uppercase tracking-wider">ER Diagram</span>
-                </div>
-                <div className="relative h-28 border border-slate-100 rounded-lg bg-slate-50 p-3 overflow-hidden">
-                  <div className="absolute top-2 left-2 bg-white border border-slate-200 shadow-sm rounded px-2 py-1 text-[8px] font-bold text-slate-700 w-16 text-center z-10">
-                    users
-                  </div>
-                  <div className="absolute top-12 right-4 bg-white border border-slate-200 shadow-sm rounded px-2 py-1 text-[8px] font-bold text-slate-700 w-16 text-center z-10">
-                    orders
-                  </div>
-                  <div className="absolute bottom-2 left-8 bg-white border border-slate-200 shadow-sm rounded px-2 py-1 text-[8px] font-bold text-slate-700 w-16 text-center z-10">
-                    payments
-                  </div>
-                  <svg className="absolute inset-0 w-full h-full pointer-events-none overflow-visible">
-                    <path d="M40 18 C 60 18, 80 40, 90 50" fill="none" stroke="#94a3b8" strokeWidth="1.5" strokeLinecap="round" />
-                    <path d="M90 65 C 80 80, 60 90, 50 90" fill="none" stroke="#94a3b8" strokeWidth="1.5" strokeLinecap="round" />
-                  </svg>
-                </div>
-              </div>
-            </CursorReactiveCard>
-
-            {/* Card 3: Schema Changes (Bottom Left) - NEAR */}
-            <CursorReactiveCard id="updates" activeId={activeId} onDistanceChange={handleDistanceChange} depth="near" className="bottom-48 left-0">
-              <div className="bg-white p-5 rounded-2xl shadow-[0_20px_40px_rgb(0,0,0,0.06)] ring-1 ring-slate-200/60 rotate-1 w-64 cursor-default transition-transform pointer-events-auto">
-                <div className="flex items-center gap-2 mb-3">
-                  <div className="p-1.5 bg-green-50 rounded-md">
-                    <Layers className="w-3.5 h-3.5 text-green-600" />
-                  </div>
-                  <span className="text-xs font-bold text-slate-800 uppercase tracking-wider">Schema Updates</span>
-                </div>
-                <div className="space-y-2.5">
-                  <div className="flex items-center gap-2 text-xs text-slate-600 bg-slate-50 p-2 rounded-lg border border-slate-100">
-                    <div className="w-1.5 h-1.5 rounded-full bg-green-500"></div>
-                    <span className="font-mono text-slate-800">users.email</span>
-                    <span className="ml-auto text-[10px] bg-green-100 text-green-700 px-1.5 py-0.5 rounded font-bold">ADDED</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-xs text-slate-600 bg-slate-50 p-2 rounded-lg border border-slate-100">
-                    <div className="w-1.5 h-1.5 rounded-full bg-amber-500"></div>
-                    <span className="font-mono text-slate-800">orders.status</span>
-                    <span className="ml-auto text-[10px] bg-amber-100 text-amber-700 px-1.5 py-0.5 rounded font-bold">MOD</span>
-                  </div>
-                </div>
-              </div>
-            </CursorReactiveCard>
-
-            {/* Card 4: Export Options (Bottom Right) - FAR */}
-            <CursorReactiveCard id="export" activeId={activeId} onDistanceChange={handleDistanceChange} depth="far" className="bottom-40 right-0">
-              <div className="bg-white p-5 rounded-2xl shadow-[0_20px_40px_rgb(0,0,0,0.06)] ring-1 ring-slate-200/60 -rotate-2 cursor-default transition-transform pointer-events-auto">
-                <div className="flex items-center gap-2 mb-4">
-                  <div className="p-1.5 bg-blue-50 rounded-md">
-                    <FileText className="w-3.5 h-3.5 text-blue-600" />
-                  </div>
-                  <span className="text-xs font-bold text-slate-800 uppercase tracking-wider">Export documentation</span>
-                </div>
-                <div className="flex gap-3">
-                  <div className="flex flex-col items-center gap-1.5">
-                    <div className="w-10 h-10 bg-slate-50 rounded-lg flex items-center justify-center border border-slate-200 text-slate-400">
-                      <span className="text-[10px] font-bold">PNG</span>
-                    </div>
-                  </div>
-                  <div className="flex flex-col items-center gap-1.5">
-                    <div className="w-10 h-10 bg-slate-50 rounded-lg flex items-center justify-center border border-slate-200 text-slate-400">
-                      <span className="text-[10px] font-bold">SVG</span>
-                    </div>
-                  </div>
-                  <div className="flex flex-col items-center gap-1.5">
-                    <div className="w-10 h-10 bg-indigo-50 rounded-lg flex items-center justify-center border border-indigo-100 text-indigo-600 shadow-sm">
-                      <FileCode className="w-5 h-5" />
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </CursorReactiveCard>
-          </div>
-        </div>
       </div>
 
       {/* Disclaimer Footer (Optional) */}


### PR DESCRIPTION
🎨 Landing Page Floating Cards Animation Enhancement
Summary
Improved the hero section floating cards with better positioning, layering, and scroll-driven fly-out animations.

Changes Made
1. Z-Index Layering

Cards now render behind the headline text (z-0 vs z-20)
Ensures headline is always readable while maintaining visual depth
Added subtle opacity (80%) to cards for a softer background effect
2. Tilted Card Alignment

Increased rotation angles on cards for a more dynamic, premium look
Top-left & bottom-right: -rotate-6
Top-right: rotate-6
Bottom-left: rotate-3
3. Scroll-Driven Fly-Out Animation

Implemented using Framer Motion's useScroll and useTransform
Cards smoothly move towards viewport corners as user scrolls:
Top-left → flies up & left
Top-right → flies up & right
Bottom-left → flies down & left
Bottom-right → flies down & right
Cards fade out (opacity 1 → 0) over first 400px of scroll
Movement completes over 500px scroll distance